### PR TITLE
Moved target for touch events to the component

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ To prevent Chrome overscroll set `overscroll-behavior-y: contain [or] none;` on 
 | resetEase | String | `cubic-bezier(0.215, 0.61, 0.355, 1)` | Ease when resetting |
 | shouldPullToRefresh | Function | `() => window.scrollY <= 0` | When to allow pulling |
 | disabled | Boolean | | Disables all functionality |
+| targetComponent | Boolean | `false` | Enable to only handle touch events on the wrapped component, otherwise all window touch events will be handled |
 
 ## Examples
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,14 +17,14 @@ class Pullable extends React.Component {
   }
 
   componentDidMount() {
-    let element = document.getElementById(this.componentId);
+    let element = this.props.targetComponent ? document.getElementById(this.componentId) : window;
     element.addEventListener('touchstart', this.onTouchStart);
     element.addEventListener('touchmove', this.onTouchMove, { passive: false });
     element.addEventListener('touchend', this.onTouchEnd);
   }
 
   componentWillUnmount() {
-    let element = document.getElementById(this.componentId);
+    let element = this.props.targetComponent ? document.getElementById(this.componentId) : window;
     element.removeEventListener('touchstart', this.onTouchStart);
     element.removeEventListener('touchmove', this.onTouchMove, { passive: false });
     element.removeEventListener('touchend', this.onTouchEnd);

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@ class Pullable extends React.Component {
 
     this.clearTouchStatus();
 
+    this.componentId = `pull-div-${Date.now() + Math.floor(Math.random() * 10000)}`;
+
     this.state = {
       status: 'ready',
       height: 0
@@ -15,15 +17,17 @@ class Pullable extends React.Component {
   }
 
   componentDidMount() {
-    window.addEventListener('touchstart', this.onTouchStart);
-    window.addEventListener('touchmove', this.onTouchMove, { passive: false });
-    window.addEventListener('touchend', this.onTouchEnd);
+    let element = document.getElementById(this.componentId);
+    element.addEventListener('touchstart', this.onTouchStart);
+    element.addEventListener('touchmove', this.onTouchMove, { passive: false });
+    element.addEventListener('touchend', this.onTouchEnd);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('touchstart', this.onTouchStart);
-    window.removeEventListener('touchmove', this.onTouchMove, { passive: false });
-    window.removeEventListener('touchend', this.onTouchEnd);
+    let element = document.getElementById(this.componentId);
+    element.removeEventListener('touchstart', this.onTouchStart);
+    element.removeEventListener('touchmove', this.onTouchMove, { passive: false });
+    element.removeEventListener('touchend', this.onTouchEnd);
 
     clearTimeout(this.refreshCompletedTimeout);
     clearTimeout(this.resetTimeout);
@@ -142,7 +146,9 @@ class Pullable extends React.Component {
             </SpinnerSVG>
           </Spinner>
         </Container>
-        {this.props.children}
+        <div id={this.componentId}>
+          {this.props.children}
+        </div>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
Currently this package will only handle touch events on the whole window. If you would like to have multiple pulldowns on the same page, or have only part of the page pullable this would not work.

My pull request creates a wrapper div for the children of the component to sit in, and it is that div that the touch events will work on if the `targetComponent` prop is set to true.

Please test this out and consider adding it to your package!

Thank you